### PR TITLE
Refactor tabs

### DIFF
--- a/cards/_components/Tab.vue
+++ b/cards/_components/Tab.vue
@@ -1,0 +1,33 @@
+<template>
+  <div class="tab-content" v-show="show">
+    <slot></slot>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'Tab',
+  props: {
+    label: {
+      type: String,
+      required: true,
+    },
+    variant: {
+      type: String,
+      default: 'dark',
+    },
+  },
+  created() {
+    this.$parent.tabs.push(this);
+    this.$parent.headers.push({
+      label: this.label,
+      variant: this.variant,
+    });
+  },
+  computed: {
+    show() {
+      return this.$parent.show === this;
+    },
+  },
+};
+</script>

--- a/cards/_components/Tabs.vue
+++ b/cards/_components/Tabs.vue
@@ -1,0 +1,109 @@
+<template>
+  <div class="p-tabs">
+    <ul class="p-tabs-headers">
+      <li
+        v-for="(header, index) in headers"
+        @click="select(index)"
+        :key="index"
+        :class="['p-tabs-header', header.variant, { active: index === active }]">
+        <span>{{ header.label }}</span>
+      </li>
+    </ul>
+    <div class="p-tabs-content">
+      <slot></slot>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'Tabs',
+  data: () => ({
+    tabs: [],
+    headers: [],
+    active: null,
+    show: null,
+  }),
+  watch: {
+    active(value) {
+      this.show = this.tabs[value];
+    },
+  },
+  created() {
+    this.active = this.startTab || 0;
+  },
+  methods: {
+    select(tabIndex) {
+      if (this.active !== tabIndex) {
+        this.active = tabIndex;
+        this.$emit('switch', tabIndex);
+      }
+    },
+  },
+  props: {
+    startTab: Number,
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+@import "~parlassets/scss/colors";
+@import "~parlassets/scss/breakpoints";
+
+.p-tabs {
+  display: flex;
+  flex-direction: column;
+  .p-tabs-headers {
+    display: flex;
+    flex-shrink: 0;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    .p-tabs-header {
+      align-items: center;
+      cursor: pointer;
+      display: flex;
+      flex: 1;
+      font-size: 13px;
+      font-weight: 300;
+      min-height: 51px;
+      justify-content: center;
+      line-height: 1.25em;
+      margin-right: 4px;
+      padding: 5px 10px;
+      text-align: center;
+      text-transform: uppercase;
+      user-select: none;
+      &:last-child { margin-right: 0; }
+      &.active {
+        cursor: default;
+        pointer-events: none;
+      }
+      @include respond-to(desktop) { font-size: 16px; }
+      &.dark {
+        background: $sadblue;
+        color: $white;
+        &.active { background: $funblue; }
+        &:hover { background: rgba($funblue, 0.7); }
+      }
+      &.light {
+        background: $grey;
+        color: $black;
+        &.active {
+          background: $funblue;
+          color: $white;
+        }
+        &:hover {
+          background: rgba($funblue, 0.7);
+          color: $white;
+        }
+      }
+    }
+  }
+  .p-tabs-content {
+    flex: 1;
+    overflow-y: auto;
+    position: relative;
+  }
+}
+</style>

--- a/cards/_components/Tabs.vue
+++ b/cards/_components/Tabs.vue
@@ -18,12 +18,14 @@
 <script>
 export default {
   name: 'Tabs',
-  data: () => ({
-    tabs: [],
-    headers: [],
-    active: null,
-    show: null,
-  }),
+  data() {
+    return {
+      tabs: [],
+      headers: [],
+      active: null,
+      show: null,
+    };
+  },
   watch: {
     active(value) {
       this.show = this.tabs[value];

--- a/cards/c/primerjalnik/card.vue
+++ b/cards/c/primerjalnik/card.vue
@@ -77,8 +77,8 @@
       </div>
     </div>
 
-    <tabs dark :switch-callback="focusTab" :start-tab="selectedTab">
-      <tab header="Seznam glasovanj">
+    <p-tabs @switch="focusTab" :start-tab="selectedTab">
+      <p-tab label="Seznam glasovanj">
         <div class="empty" v-if="filteredVotes.length === 0"></div>
         <div v-else id="votingCard" class="date-list">
           <div class="session_voting">
@@ -148,16 +148,16 @@
             </div>
           </div>
         </div>
-      </tab>
-      <tab header="Dinamika skozi čas">
+      </p-tab>
+      <p-tab label="Dinamika skozi čas">
         <div class="empty" v-if="filteredVotes.length === 0"></div>
         <time-chart v-if="filteredVotes.length !== 0" :data="data"></time-chart>
-      </tab>
-      <tab header="Dinamika glede na MDT" class="tab-three">
+      </p-tab>
+      <p-tab label="Dinamika glede na MDT" class="tab-three">
         <div v-if="filteredVotes.length === 0" class="empty"></div>
         <bar-chart v-else :data="barChartData" show-numbers></bar-chart>
-      </tab>
-    </tabs>
+      </p-tab>
+    </p-tabs>
 
     <div v-show="sameModalVisible" class="card-modal">
       <div class="card-modal-header">
@@ -210,13 +210,17 @@
 
 <script>
   import common from 'mixins/common';
+  import PTab from 'components/Tab.vue';
+  import PTabs from 'components/Tabs.vue';
   import TimeChart from 'components/TimeChart.vue';
   import BarChart from 'components/BarChart.vue';
 
   export default {
     components: {
-      TimeChart,
       BarChart,
+      TimeChart,
+      PTab,
+      PTabs,
     },
     mixins: [common],
     name: 'PrimerjalnikGlasovanj',

--- a/cards/devBundle.js
+++ b/cards/devBundle.js
@@ -1,4 +1,5 @@
 /* eslint-disable */
+import Vue from 'vue';
 import Card from 'cardPath/card.vue';
 import cardData from 'cardPath/card.json';
 import data from 'cardPath/data.json';

--- a/cards/obcasnik/amandmaji/card.vue
+++ b/cards/obcasnik/amandmaji/card.vue
@@ -14,27 +14,31 @@
       <p class="info-text">Število amandmajev, ki jih vložila posamezna poslanska skupina dobimo tako, da preštejemo vsa glasovanja, v imenu katerih se pojavi beseda amandma. Med preštetimi glasovanji poiščemo tista, katerih ime vsebije kratico poslanske skupine. Ta amandma prištejemo k tej poslanski skupini.</p>
     </div>
 
-    <tabs dark :switch-callback="focusTab">
-      <tab header="Št. članov PS">
+    <p-tabs @switch="focusTab">
+      <p-tab label="Št. članov PS">
         <bar-chart :data="seatCountData" show-numbers></bar-chart>
-      </tab>
-      <tab header="Št. vloženih amandmajev">
+      </p-tab>
+      <p-tab label="Št. vloženih amandmajev">
         <bar-chart :data="amandmajiData" show-numbers></bar-chart>
-      </tab>
-      <tab header="Št. vloženih amandmajev na poslanca">
+      </p-tab>
+      <p-tab label="Št. vloženih amandmajev na poslanca">
         <bar-chart :data="amandmajiNaPoslancaData" show-numbers></bar-chart>
-      </tab>
-    </tabs>
+      </p-tab>
+    </p-tabs>
   </card-wrapper>
 </template>
 
 <script>
 import common from 'mixins/common';
 import BarChart from 'components/BarChart.vue';
+import PTab from 'components/Tab.vue';
+import PTabs from 'components/Tabs.vue';
 
 export default {
   components: {
-    BarChart
+    BarChart,
+    PTab,
+    PTabs,
   },
   mixins: [common],
   name: 'ObcasnikAmandmaji',

--- a/cards/p/clanstva/card.vue
+++ b/cards/p/clanstva/card.vue
@@ -10,11 +10,12 @@
       <p class="info-text">Podatki o članstvih pridobljeni s spletnega mesta <a href="https://www.dz-rs.si/wps/portal/Home/ODrzavnemZboru/KdoJeKdo/PoslankeInPoslanci/PoAbecedi" target="_blank" class="funblue-light-hover">DZ RS</a>.</p>
     </div>
 
-    <tabs>
-      <tab
+    <p-tabs>
+      <p-tab
         v-for="(tabContents, tabName) in tabs"
         :key="tabName"
-        :header="tabName">
+        :label="tabName"
+        variant="light">
         <ul class="membership-list">
           <template v-if="tabContents.length">
             <li
@@ -33,8 +34,8 @@
           </template>
           <div v-else class="no-results"><i>Brez članstev.</i></div>
         </ul>
-      </tab>
-    </tabs>
+      </p-tab>
+    </p-tabs>
   </card-wrapper>
 </template>
 
@@ -42,9 +43,11 @@
 import { reduce } from 'lodash';
 import common from 'mixins/common';
 import { member } from 'mixins/altHeaders';
+import PTab from 'components/Tab.vue';
+import PTabs from 'components/Tabs.vue';
 
 export default {
-  components: { },
+  components: { PTab, PTabs },
   mixins: [common, member],
   name: 'Clanstva',
   data() {
@@ -92,7 +95,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-.tabs {
+.p-tabs {
   flex: 1;
   height: 180px;
 }

--- a/cards/s/glasovanje/card.vue
+++ b/cards/s/glasovanje/card.vue
@@ -46,16 +46,16 @@
         />
       </div>
     </div>
-    <tabs dark :switch-callback="focusTab" :start-tab="selectedTab">
-      <tab header="Poslanci">
+    <p-tabs @switch="focusTab" :start-tab="selectedTab">
+      <p-tab label="Poslanci">
         <poslanci
           :members="data.members"
           :member-votes="data.all"
           :result="data.result"
           :state="state"
         />
-      </tab>
-      <tab header="Poslanske skupine">
+      </p-tab>
+      <p-tab label="Poslanske skupine">
         <poslanske-skupine
           ref="parties"
           :members="data.members"
@@ -64,8 +64,8 @@
           :selectedParty="state.selectedParty || null"
           :selectedOption="state.selectedOption || null"
         />
-      </tab>
-      <tab header="Stran vlade">
+      </p-tab>
+      <p-tab label="Stran vlade">
         <poslanske-skupine
           ref="sides"
           :members="data.members"
@@ -74,19 +74,21 @@
           :selectedParty="state.selectedParty || null"
           :selectedOption="state.selectedOption || null"
         />
-      </tab>
-    </tabs>
+      </p-tab>
+    </p-tabs>
   </card-wrapper>
 </template>
 
 <script>
 import { find, pick } from 'lodash';
 import common from 'mixins/common';
+import PTab from 'components/Tab.vue';
+import PTabs from 'components/Tabs.vue';
 import Poslanci from './Poslanci.vue';
 import PoslanskeSkupine from './PoslanskeSkupine.vue';
 
 export default {
-  components: { Poslanci, PoslanskeSkupine },
+  components: { Poslanci, PoslanskeSkupine, PTab, PTabs },
   mixins: [common],
   name: 'GlasovanjeSeje',
   data() {

--- a/cards/serverBundle.js
+++ b/cards/serverBundle.js
@@ -1,8 +1,6 @@
 import Vue from 'vue';
 import request from 'request';
 import SearchDropdown from 'parlassets/components/SearchDropdown.vue';
-import Tabs from 'parlassets/components/Tabs.vue';
-import Tab from 'parlassets/components/Tab.vue';
 // eslint-disable-next-line
 import Card from 'cardPath/card.vue';
 
@@ -21,8 +19,6 @@ global.$ = {
   },
 };
 Vue.component('SearchDropdown', SearchDropdown);
-Vue.component('Tabs', Tabs);
-Vue.component('Tab', Tab);
 
 // the default export should be a function
 // which will receive the context of the render call


### PR DESCRIPTION
Changes:
- `Tab` and `Tabs` components are no longer loaded from the pre-built bundle in `parlassets`, they are now directly imported in `parlanode` as PTab/PTabs (p is for parlameter) to avoid conflicts with the globally registered ones that are not yet removed;
- `devBundle.js` is updated to import Vue instead of relying on the global instance, which fixes the weird bug where local importing caused errors;
- instead of passing a switch callback to the tabs, they emit a `switch` event with the newly selected index in payload whenever a switch happens;
- instead of setting `dark` directly on the `tabs` component, each tab now has a variant property, which can be `"light"` or `"dark"` (default) - this is added in anticipation of incoming law cards with mixed tab colors;
- tab styling is slightly adjusted so that dark and light tabs only differ in color;
- all Vue-based cards that use tabs are updated with new changes.
