### PR TITLE
Allow tab completion of card names in command line

### DIFF
--- a/cards/build.js
+++ b/cards/build.js
@@ -61,6 +61,12 @@ if (process.env.CARD_NAME === '') {
   const paths = dirs('./cards/p').concat(dirs('./cards/ps')).concat(dirs('./cards/s').concat(dirs('./cards/c')));
   paths.reduce((promise, path) => promise.then(() => compileAndRefresh(path)), Promise.resolve());
 } else {
-  compileAndRefresh(`./cards/${process.env.CARD_NAME}`);
+  let cardName = process.env.CARD_NAME;
+
+  if (cardName.indexOf('cards/') === 0) {
+    cardName = cardName.replace('cards/', '');
+  }
+
+  compileAndRefresh(`./cards/${cardName}`);
 }
 

--- a/cards/webpack.config.dev.js
+++ b/cards/webpack.config.dev.js
@@ -4,7 +4,13 @@ const webpack = require('webpack');
 const baseConfig = require('./webpack.config.base');
 
 module.exports = () => {
-  const config = baseConfig(`${path.resolve(__dirname)}/${process.env.CARD_NAME}`);
+  let cardName = process.env.CARD_NAME;
+
+  if (cardName.indexOf('cards/') === 0) {
+    cardName = cardName.replace('cards/', '');
+  }
+
+  const config = baseConfig(`${path.resolve(__dirname)}/${cardName}`);
 
   return Object.assign(config, {
     entry: './cards/devBundle.js',


### PR DESCRIPTION
A very long time ago, I promised someone (99.9% sure it was @muki) to somehow enable card name tab completion for `yarn run cards-[dev|build]`. I looked into it for a while and the prettiest solution (autocompleting just `p/clanstva`) would probably require implementing our own CLI tool, which seemed like overkill. So this is the lazy way where you have to prefix it with `cards/` and then just use the built-in tab completion.

The old way still works, so this is a non-breaking change.