### PR TITLE
feat--export-button

### DIFF
--- a/parlacards/cards/_components/Card/Export.vue
+++ b/parlacards/cards/_components/Card/Export.vue
@@ -1,0 +1,43 @@
+<template>
+  <div class="card-content-export">
+    <div class="card-back-content">
+      <div class="export-content">
+        <p v-t="'card.export'"></p>
+        <a
+          class="btn-parlameter btn btn-full-width btn-blue"
+          :href="exportUrl('csv')"
+          target="_blank"
+        >
+          <span v-t="'export.csv'"></span>
+        </a>
+        <a
+          class="btn-parlameter btn btn-full-width btn-blue"
+          :href="exportUrl('json')"
+          target="_blank"
+        >
+          <span v-t="'export.json'"></span>
+        </a>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+
+export default {
+  name: 'CardExport',
+  data() {
+    const { cardName, urls } = this.$root.$options.contextData;
+    return {
+      cardName,
+      urls,
+      mandate_id: 1
+    };
+  },
+  methods: {
+    exportUrl(format) {
+      return `${this.urls.data}/export/${this.cardName}.${format}?mandate_id=${this.mandate_id}`;
+    }
+  }
+};
+</script>

--- a/parlacards/cards/_components/Card/Footer.vue
+++ b/parlacards/cards/_components/Card/Footer.vue
@@ -39,12 +39,17 @@ export default {
   },
   computed: {
     buttons() {
-      const { cardData } = this.$root.$options.contextData;
+      const buttonsList = ['share', 'embed', 'info'];
+      const { cardData, cardState } = this.$root.$options.contextData;
       const previous = cardData?.data?.previous_versions;
       if (previous && previous.length) {
-        return ['share', 'embed', 'info', 'previous'];
+        buttonsList.push('previous');
       }
-      return ['share', 'embed', 'info'];
+      const showExportButton = cardState?.showExportButton;
+      if (showExportButton) {
+        buttonsList.push('export')
+      }
+      return buttonsList;
     },
   },
   methods: {

--- a/parlacards/cards/_components/Card/Header.vue
+++ b/parlacards/cards/_components/Card/Header.vue
@@ -34,6 +34,7 @@
       <h1 v-else-if="currentBack === 'embed'" v-t="'embed.title'"></h1>
       <h1 v-else-if="currentBack === 'share'" v-t="'share.title'"></h1>
       <h1 v-else-if="currentBack === 'previous'" v-t="'previous.title'"></h1>
+      <h1 v-else-if="currentBack === 'export'" v-t="'export.title'"></h1>
       <h1 v-else>{{ config.title }}</h1>
     </template>
   </div>

--- a/parlacards/cards/_components/Card/Wrapper.vue
+++ b/parlacards/cards/_components/Card/Wrapper.vue
@@ -23,6 +23,8 @@
 
         <card-previous v-else-if="currentBack === 'previous'" />
 
+        <card-export v-else-if="currentBack === 'export'" />
+
         <div v-else v-cloak class="card-content-front">
           <slot />
         </div>
@@ -38,6 +40,7 @@ import CardInfo from '@/_components/Card/Info.vue';
 import CardEmbed from '@/_components/Card/Embed.vue';
 import CardShare from '@/_components/Card/Share.vue';
 import CardPrevious from '@/_components/Card/Previous.vue';
+import CardExport from '@/_components/Card/Export.vue';
 import CardHeader from '@/_components/Card/Header.vue';
 import CardFooter from '@/_components/Card/Footer.vue';
 
@@ -48,6 +51,7 @@ export default {
     CardEmbed,
     CardShare,
     CardPrevious,
+    CardExport,
     CardHeader,
     CardFooter,
   },

--- a/parlacards/cards/_i18n/sl/defaults.yaml
+++ b/parlacards/cards/_i18n/sl/defaults.yaml
@@ -218,6 +218,10 @@ embed:
   always-refresh: Podatki naj se vedno osvežujejo
 previous:
   title: Prejšnje verzije
+export:
+  title: Izvozi podatke
+  csv: Izvozi v .csv
+  json: Izvozi v .json
 membership-list:
   no-memberships: Brez članstev.
 style-scores:

--- a/parlacards/cards/_i18n/sl/misc/members.yaml
+++ b/parlacards/cards/_i18n/sl/misc/members.yaml
@@ -1,5 +1,6 @@
 card:
   title: Seznam poslancev
+  export: navodila to be
   info: >-
     # Množica vseh trenutno aktivnih poslancev, ki ustrezajo uporabniškemu vnosu.
 

--- a/parlacards/cards/misc/members/state.json
+++ b/parlacards/cards/misc/members/state.json
@@ -7,5 +7,6 @@
   "showDemographicsEducation": "true",
   "showDemographicsMandates": "true",
   "showDemographicsGroup": "true",
+  "showExportButton": "true",
   "hiddenAnalyses": "spoken_words|mismatch_of_pg"
 }

--- a/parlacards/cards/misc/votes/state.json
+++ b/parlacards/cards/misc/votes/state.json
@@ -1,1 +1,3 @@
-{}
+{
+    "showExportButton": "true"
+}


### PR DESCRIPTION
Add an EXPORT button to any card by setting `showExportButton=true` in the card state.
Button is placed next to other Footer buttons on the card.

`Export.vue` component contains the content that will be shown when export button is clicked (similarly to `Share.vue`, `Info.vue`,...). Instructions for each card should be written to translation .yaml files under key card.export
The url to export api is automatically created, as data api endpoints reflect cards path structure. Mandate id is a required parameter and is for now hardcoded to be 1.

Check examples at:
http://localhost:3000/misc/members
http://localhost:3000/misc/votes